### PR TITLE
Add back button to new applicant creation page

### DIFF
--- a/hiring_system_flask - Copy/templates/recruiter_create_case.html
+++ b/hiring_system_flask - Copy/templates/recruiter_create_case.html
@@ -1,0 +1,187 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h3 class="mb-0">ایجاد پرونده</h3>
+  <a href="{{ url_for('recruiter.dashboard') }}" class="btn btn-light">بازگشت به پنل</a>
+</div>
+
+{% with msgs = get_flashed_messages(with_categories=true) %}
+  {% if msgs %}
+    {% for cat, msg in msgs %}
+      <div class="alert alert-{{ 'danger' if cat=='danger' else cat }} py-2">{{ msg }}</div>
+    {% endfor %}
+  {% endif %}
+{% endwith %}
+
+<div class="card shadow-sm">
+  <div class="card-body">
+    <form method="post" class="row g-3" id="createForm">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <!-- این‌ها برای مودال‌های تکراری‌بودن موبایل استفاده می‌شوند -->
+      <input type="hidden" name="dup_confirm" id="dup_confirm" value="0">
+      <input type="hidden" name="dup_action"  id="dup_action"  value="">
+
+      <!-- هویتی/تماس -->
+      <div class="col-md-4">
+        <label class="form-label">نام و نام‌خانوادگی</label>
+        <input name="full_name" class="form-control" value="{{ form.full_name.data or '' }}" required>
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">کدملی</label>
+        <input name="national_id" id="national_id" class="form-control" value="{{ form.national_id.data or '' }}" required>
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">موبایل</label>
+        <input name="mobile" id="mobile" class="form-control" value="{{ form.mobile.data or '' }}" required>
+      </div>
+
+      <!-- سازمان/قرارداد -->
+      <div class="col-md-4">
+        <label class="form-label">نوع قرارداد</label>
+        <input name="contract_type" class="form-control" value="{{ form.contract_type.data or '' }}">
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">سمت سازمانی</label>
+        <input name="org_position" class="form-control" value="{{ form.org_position.data or '' }}">
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">مدرک تحصیلی</label>
+        <input name="degree" class="form-control" value="{{ form.degree.data or '' }}">
+      </div>
+
+      <!-- شعبه -->
+      <div class="col-md-6">
+        <label class="form-label">نام مدیر شعبه</label>
+        <input name="branch_manager_name" class="form-control" value="{{ form.branch_manager_name.data or '' }}">
+      </div>
+      <div class="col-md-6">
+        <label class="form-label">آدرس شعبه</label>
+        <input name="branch_address" class="form-control" value="{{ form.branch_address.data or '' }}">
+      </div>
+
+      <!-- حقوق -->
+      <div class="col-md-6">
+        <label class="form-label">نوع حقوق</label>
+        <input name="approved_salary_type" class="form-control" value="{{ form.approved_salary_type.data or '' }}">
+      </div>
+      <div class="col-md-6">
+        <label class="form-label">حقوق تایید شده</label>
+        <input name="approved_salary_amount" id="approved_salary_amount" class="form-control" value="{{ form.approved_salary_amount.data or '' }}">
+      </div>
+
+      <div class="col-12 d-flex gap-2">
+        <button class="btn btn-primary">ثبت پرونده</button>
+        <a href="{{ url_for('recruiter.dashboard') }}" class="btn btn-light">بازگشت</a>
+      </div>
+    </form>
+  </div>
+</div>
+
+<!-- مودال تکراری بودن موبایل: مرحلهٔ اول -->
+{% if show_dup_modal %}
+<div class="modal fade show" id="dup1" tabindex="-1" style="display:block; background:rgba(0,0,0,.5);">
+  <div class="modal-dialog">
+    <div class="modal-content glass shadow">
+      <div class="modal-header"><h6 class="modal-title">شماره موبایل تکراری</h6></div>
+      <div class="modal-body">این شماره موبایل قبلاً ثبت شده است. آیا ادامه می‌دهید؟</div>
+      <div class="modal-footer">
+        <a href="{{ url_for('recruiter.create_case') }}" class="btn btn-secondary">خیر</a>
+        <button class="btn btn-primary" id="btnDupYes">بله</button>
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+  document.getElementById('btnDupYes')?.addEventListener('click', ()=>{
+    document.getElementById('dup_confirm').value = '1';
+    document.getElementById('createForm').submit();
+  });
+</script>
+{% endif %}
+
+<!-- مودال گزینه‌ها: مشاهدهٔ کاربر قبلی / ساخت اکانت جدید -->
+{% if show_dup_options_modal %}
+<div class="modal fade show" id="dup2" tabindex="-1" style="display:block; background:rgba(0,0,0,.5);">
+  <div class="modal-dialog">
+    <div class="modal-content glass shadow">
+      <div class="modal-header"><h6 class="modal-title">انتخاب اقدام</h6></div>
+      <div class="modal-body">
+        <p class="mb-2">اطلاعات کاربر قبلی با این موبایل:</p>
+        <div class="p-2 bg-light rounded">
+          <div><strong>نام:</strong> {{ dup_user.full_name }}</div>
+          <div><strong>نام‌کاربری:</strong> {{ dup_user.username }}</div>
+          <div><strong>موبایل:</strong> {{ dup_user.mobile }}</div>
+          <div><strong>نقش:</strong> {{ dup_user.role and dup_user.role.name or '' }}</div>
+        </div>
+        <p class="mt-3">آیا می‌خواهید اکانت جدید بسازید یا از همین کاربر استفاده شود؟</p>
+      </div>
+      <div class="modal-footer">
+        <a href="{{ url_for('recruiter.create_case') }}" class="btn btn-secondary">بازگشت</a>
+        <button class="btn btn-outline-primary" id="btnUsePrev">استفاده از کاربر موجود</button>
+        <button class="btn btn-primary" id="btnCreateNew">ساخت اکانت جدید</button>
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+  document.getElementById('btnUsePrev')?.addEventListener('click', ()=>{
+    document.getElementById('dup_confirm').value = '1';
+    document.getElementById('dup_action').value = 'view';
+    document.getElementById('createForm').submit();
+  });
+  document.getElementById('btnCreateNew')?.addEventListener('click', ()=>{
+    document.getElementById('dup_confirm').value = '1';
+    document.getElementById('dup_action').value = 'create';
+    document.getElementById('createForm').submit();
+  });
+</script>
+{% endif %}
+
+<!-- مودال نتیجه (ارسال/عدم‌ارسال SMS یا هر پیام وضعیت) -->
+{% if modal %}
+<div class="modal fade" id="resultModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content border-0">
+      <div class="modal-header {{ 'bg-success text-white' if modal.status in ['ok','sent'] else 'bg-danger text-white' }}">
+        <h5 class="modal-title">{{ modal.title }}</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p class="mb-0">{{ modal.text }}</p>
+      </div>
+      <div class="modal-footer">
+        <a class="btn btn-light" href="{{ url_for('recruiter.dashboard') }}">بازگشت به داشبورد</a>
+        <a class="btn btn-primary" href="{{ url_for('recruiter.create_case') }}">ثبت پروندهٔ جدید</a>
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+  (function () {
+    var el = document.getElementById('resultModal');
+    if (el) new bootstrap.Modal(el).show();
+  })();
+</script>
+{% endif %}
+
+<style>
+  .glass{backdrop-filter:blur(8px);background:rgba(255,255,255,.85);}
+</style>
+
+<!-- نرمال‌سازی اعداد فارسی/عربی به انگلیسی برای ورودی‌های عددی -->
+<script>
+  function toEnDigits(s){
+    if(!s) return s;
+    const fa = "۰۱۲۳۴۵۶۷۸۹", ar = "٠١٢٣٤٥٦٧٨٩";
+    return s.replace(/[۰-۹]/g, d=>fa.indexOf(d))
+            .replace(/[٠-٩]/g, d=>ar.indexOf(d));
+  }
+  ["national_id","mobile","approved_salary_amount"].forEach(id=>{
+    const el = document.getElementById(id);
+    if(el){
+      el.addEventListener("input", ()=>{ el.value = toEnDigits(el.value); });
+      el.value = toEnDigits(el.value);
+    }
+  });
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add a top-level back button on the new applicant creation page to navigate to the recruiter dashboard

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abeacbd534832684f8fcc3d7974665